### PR TITLE
fix an issue

### DIFF
--- a/luacs/source.lua
+++ b/luacs/source.lua
@@ -289,7 +289,7 @@ function methods:match_namespace_prefix()
 end
 
 function methods:match_hash()
-  matched = self:match("#[_%a%d-]+")
+  local matched = self:match("#[_%a%d-]+")
   if matched then
     return matched:sub(2)
   else


### PR DESCRIPTION
_G write guard:12: __newindex(): writing a global lua variable ('matched') which may lead to race conditions between concurrent requests, so prefer the use of 'local' variables
stack traceback:
	/data/work/lualib/luacs/luacs/source.lua:292: in function 'match_hash'
	/data/work/lualib/luacs/luacs/parser.lua:190: in function 'hash'
	/data/work/lualib/luacs/luacs/parser.lua:423: in function 'simple_selector_sequence'
	/data/work/lualib/luacs/luacs/parser.lua:475: in function 'selector'
	/data/work/lualib/luacs/luacs/parser.lua:491: in function 'selectors_group'
	/data/work/lualib/luacs/luacs/parser.lua:518: in function 'parse'
	/data/work/lualib/luacs/luacs.lua:11: in function 'to_xpaths'
	/data/work/lualib/xmlua/xmlua/searchable.lua:112: in function
    'css_select'